### PR TITLE
Corrects value passed to nLabelWindowScale

### DIFF
--- a/ui/ui_settings/ui_tab_video/ui-tab-video.gd
+++ b/ui/ui_settings/ui_tab_video/ui-tab-video.gd
@@ -25,7 +25,7 @@ func set_window_scale( new_scale: int ) -> void:
 	else:
 		nCheckButtonFullScreen.button_pressed = false
 	#	Update information to player.
-	nLabelWindowScale.text = String.num( new_scale )
+	nLabelWindowScale.text = String.num( GlobalUserSettings.get_window_scale() )
 	nLabelGameScale.text = String.num( GlobalUserSettings.get_game_scale() )
 
 


### PR DESCRIPTION
The bug was caused by the new_scale argument being directly passed to the label, when it needed to be obtaining the info as it is stored in the settings data.