### PR TITLE
Corrects tween error and fade states

### DIFF
--- a/addons/gdtemplate/ui/global-ui-screenfade.gd
+++ b/addons/gdtemplate/ui/global-ui-screenfade.gd
@@ -25,19 +25,17 @@ func set_percent( value: float ) -> void:
 	nColorRect.modulate.a = percent
 
 
-func set_state( value: int ) -> void:
-	var tween = get_tree().create_tween()
-	state = value
-	match state:
-		FADE_OUT:
-			#	Fading to black
-			tween.tween_property( self, "percent", 0.0, 0.5 )
-			tween.play()
-		FADE_IN:
-			#	Fading from black
-			tween.tween_property( self, "percent", 1.0, 0.5 )
-			tween.play()
+func set_state( new_value: int ) -> void:
+	var tween: Tween
+	var final_opacity_value: float = 0.0
+	state = new_value
 	visible = true
+	if( state == FADE_OUT ):
+		final_opacity_value = 1.0
+	#	Create new tween.
+	tween = get_tree().create_tween()
+	tween.tween_property( self, "percent", final_opacity_value, 0.5 )
+	tween.play()
 	await tween.finished
 	tween.kill()
 	_on_tween_finished()

--- a/rooms/room_main/signals/signals-main.gd
+++ b/rooms/room_main/signals/signals-main.gd
@@ -11,12 +11,12 @@ func _on_scene_change( new_scene: String ) -> void:
 	var game_contents: Array = owner.nGame.get_children()
 	for content in game_contents:
 		content.destroy()
-	GlobalUIScreenFade.set_state( GlobalUIScreenFade.FADE_IN )
+	GlobalUIScreenFade.set_state( GlobalUIScreenFade.FADE_OUT )
 	await GlobalUIScreenFade.fade_complete
 	#	TODO: Convert to loading screen.
 	owner.nGame.add_child( load( new_scene ).instantiate() )
 	owner.nUI.visible = false
-	GlobalUIScreenFade.set_state( GlobalUIScreenFade.FADE_OUT )
+	GlobalUIScreenFade.set_state( GlobalUIScreenFade.FADE_IN )
 
 
 func _on_menu_new_game( first_room: String ) -> void:


### PR DESCRIPTION
Main now properly fades out and then fades in to the next scene, tween does not produce error, anymore.