### PR TITLE
Adds fallback logarithmic max font size formula.

### DIFF
--- a/addons/gdtemplate/autoload/global-theme.gd
+++ b/addons/gdtemplate/autoload/global-theme.gd
@@ -2,6 +2,12 @@ extends Node
 
 signal new_fontlist
 
+#	Fallback logarithmic formula for font scaling.
+#	f(x) = offset + ( scale * log( x ^ exponent ) )
+const MAX_FONT_OFFSET: int = 26
+const MAX_FONT_SCALE: int = 140
+const MAX_FONT_EXPONENT: float = 0.8
+
 var theme: Theme
 var thread_font: Thread
 var thread_font_size: Thread
@@ -26,6 +32,13 @@ var font_list: Dictionary = {
 
 func set_theme( new_theme: Theme ) -> void:
 	theme = new_theme
+
+
+func get_maximum_font_sizes( index: int ) -> int:
+	if( index < maximum_font_sizes.size() ):
+		return maximum_font_sizes[ index ]
+	return MAX_FONT_OFFSET + round( MAX_FONT_SCALE * \
+			log( pow( index, MAX_FONT_EXPONENT ) ) )
 
 
 func get_font( font_name: String ) -> Font:

--- a/ui/ui_first_setup/ui-first-setup.gd
+++ b/ui/ui_first_setup/ui-first-setup.gd
@@ -32,8 +32,8 @@ const MINIMUM_FONT_SIZE: int = 8
 
 func set_font_size( new_size: int ) -> void:
 	var adjusted_size: int = new_size
-	var maximum_font_size: int = GlobalTheme.maximum_font_sizes[
-			GlobalUserSettings.get_game_scale() - 1 ]
+	var maximum_font_size: int = GlobalTheme.get_maximum_font_size(
+			GlobalUserSettings.get_game_scale() - 1 )
 	new_size = clamp( new_size, MINIMUM_FONT_SIZE, maximum_font_size )
 	GlobalUserSettings.set_current_font_size( new_size )
 	GlobalUserSettings.save_settings()

--- a/ui/ui_settings/ui_tab_accessibility/ui-tab-accessibility.gd
+++ b/ui/ui_settings/ui_tab_accessibility/ui-tab-accessibility.gd
@@ -18,8 +18,8 @@ const DEFAULT_FONT_INDEX: int = 0
 
 func set_font_size( new_size: int ) -> void:
 	var adjusted_size: int = new_size
-	var maximum_font_size: int = GlobalTheme.maximum_font_sizes[
-			GlobalUserSettings.get_game_scale() - 1 ]
+	var maximum_font_size: int = GlobalTheme.get_maximum_font_sizes(
+			GlobalUserSettings.get_game_scale() - 1 )
 	new_size = clamp( new_size, MINIMUM_FONT_SIZE, maximum_font_size )
 	GlobalUserSettings.set_current_font_size( new_size )
 	GlobalUserSettings.save_settings()


### PR DESCRIPTION
Resolves #24 by utilizing a fallback formula that can be adjusted in the theme autoload singleton. Admittedly this was just eyeballed for the default fonts.