### PR TITLE
Mouseinput scrolls container to expose tabs

### DIFF
--- a/addons/gdtemplate/ui/ui_button_tab/ui-button-tab.gd
+++ b/addons/gdtemplate/ui/ui_button_tab/ui-button-tab.gd
@@ -11,6 +11,7 @@ Notes:
 Debug Info:
 	No debug info.
 """
+signal clicked( button: ButtonTab )
 ## Reference to the content that is associated with this ButtonTab.
 @export var n_VBCTab: VBoxContainer = null
 
@@ -28,6 +29,10 @@ func _on_focus_entered() -> void:
 	for button in buttons:
 		button.n_VBCTab.visible = false
 	n_VBCTab.visible = true
+
+
+func _on_pressed() -> void:
+	emit_signal( "clicked", self )
 
 
 func _ready() -> void:

--- a/addons/gdtemplate/ui/ui_button_tab/ui-button-tab.tscn
+++ b/addons/gdtemplate/ui/ui_button_tab/ui-button-tab.tscn
@@ -1,9 +1,9 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene load_steps=2 format=3 uid="uid://dk5r287n3ijqv"]
 
 [ext_resource type="Script" path="res://addons/gdtemplate/ui/ui_button_tab/ui-button-tab.gd" id="1_7ur2y"]
-
 
 [node name="ButtonTab" type="Button"]
 script = ExtResource("1_7ur2y")
 
 [connection signal="focus_entered" from="." to="." method="_on_focus_entered"]
+[connection signal="pressed" from="." to="." method="_on_pressed"]

--- a/ui/ui_settings/signals/signals-ui-settings.gd
+++ b/ui/ui_settings/signals/signals-ui-settings.gd
@@ -21,11 +21,15 @@ func _on_new_fontlist() -> void:
 	owner.nTabAccessibility.populate_font_list()
 	owner.nTabAccessibility.set_font(
 			owner.nTabAccessibility.DEFAULT_FONT_INDEX )
-	
-	
-	"""
-		Ready
-	"""
+
+
+func _on_buttontab_clicked( button: ButtonTab ) -> void:
+	var mid_point: int = ( owner.nSCTabsWrap.size.x / 2.0 ) as int
+	var button_x: int = button.get_position().x + ( button.size.x / 2 )
+	var scroll_x: int = owner.nSCTabsWrap.scroll_horizontal
+	owner.nSCTabsWrap.scroll_horizontal = button_x - mid_point
+
+
 
 func connect_signals() -> void:
 	GlobalTheme.new_fontlist.connect(

--- a/ui/ui_settings/ui-settings.gd
+++ b/ui/ui_settings/ui-settings.gd
@@ -4,8 +4,10 @@ signal menu_settings_closed
 signal new_language
 
 @onready var nSignals: Node = get_node( "Signals" )
-@onready var nButtonAccessibility: Button = get_node(
-		"VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonAccessibility" )
+@onready var nSCTabsWrap: ScrollContainer = get_node(
+		"VBCSettings/HBCTabs/SCTabsWrap" )
+@onready var nButtonAccessibility: Button = nSCTabsWrap.get_node(
+		"HBCTabsClip/ButtonAccessibility" )
 @onready var nTabControls: VBoxContainer = get_node(
 		"VBCSettings/ColorRect/VBCControls" )
 @onready var nTabAccessibility: VBoxContainer = get_node(

--- a/ui/ui_settings/ui-settings.tscn
+++ b/ui/ui_settings/ui-settings.tscn
@@ -319,8 +319,8 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = 4.0
 offset_top = 4.0
-offset_right = -4.0
-offset_bottom = -4.0
+offset_right = 396.0
+offset_bottom = 246.0
 grow_horizontal = 2
 grow_vertical = 2
 alignment = 1
@@ -371,8 +371,8 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 offset_left = 4.0
 offset_top = 4.0
-offset_right = -4.0
-offset_bottom = -4.0
+offset_right = 396.0
+offset_bottom = 246.0
 grow_horizontal = 2
 grow_vertical = 2
 alignment = 1
@@ -636,11 +636,21 @@ BUS_ID = 4
 modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 
+[connection signal="clicked" from="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonAccessibility" to="Signals" method="_on_buttontab_clicked"]
 [connection signal="focus_entered" from="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonAccessibility" to="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonAccessibility" method="_on_focus_entered"]
+[connection signal="pressed" from="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonAccessibility" to="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonAccessibility" method="_on_pressed"]
+[connection signal="clicked" from="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonControls" to="Signals" method="_on_buttontab_clicked"]
 [connection signal="focus_entered" from="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonControls" to="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonControls" method="_on_focus_entered"]
+[connection signal="pressed" from="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonControls" to="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonControls" method="_on_pressed"]
+[connection signal="clicked" from="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonGameplay" to="Signals" method="_on_buttontab_clicked"]
 [connection signal="focus_entered" from="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonGameplay" to="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonGameplay" method="_on_focus_entered"]
+[connection signal="pressed" from="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonGameplay" to="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonGameplay" method="_on_pressed"]
+[connection signal="clicked" from="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonVideo" to="Signals" method="_on_buttontab_clicked"]
 [connection signal="focus_entered" from="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonVideo" to="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonVideo" method="_on_focus_entered"]
+[connection signal="pressed" from="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonVideo" to="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonVideo" method="_on_pressed"]
+[connection signal="clicked" from="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonAudio" to="Signals" method="_on_buttontab_clicked"]
 [connection signal="focus_entered" from="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonAudio" to="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonAudio" method="_on_focus_entered"]
+[connection signal="pressed" from="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonAudio" to="VBCSettings/HBCTabs/SCTabsWrap/HBCTabsClip/ButtonAudio" method="_on_pressed"]
 [connection signal="pressed" from="VBCSettings/HBCTabs/ButtonCloseSettings" to="Signals" method="_on_button_close_settings_pressed"]
 [connection signal="item_selected" from="VBCSettings/ColorRect/VBCAccessibility/HBCLanguages/OptionButtonLanguage" to="VBCSettings/ColorRect/VBCAccessibility/Signals" method="_on_option_button_language_item_selected"]
 [connection signal="new_index" from="VBCSettings/ColorRect/VBCAccessibility/HBCFonts/ButtonCycleFont" to="VBCSettings/ColorRect/VBCAccessibility/Signals" method="_on_button_cycle_font_new_index"]


### PR DESCRIPTION
Clicking tabs would not bring the tab into view enough that the next tab was exposed. This resolves the issue by centering the tab in the middle of the scrollcontainer's view, or getting as close as possible, if needed.